### PR TITLE
Redis Persistent Log

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem 'celluloid', github: 'celluloid/celluloid'
 gem 'celluloid-io', github: 'celluloid/celluloid-io'
 gem 'celluloid-zmq', github: 'celluloid/celluloid-zmq'
+gem 'celluloid-redis', github: 'celluloid/celluloid-redis'
 
 group :docs do
   gem 'yard'

--- a/examples/distributed_hash_redis.rb
+++ b/examples/distributed_hash_redis.rb
@@ -1,0 +1,39 @@
+$: << File.expand_path('../../lib', __FILE__)
+
+require 'floss/test_helper'
+require 'floss/proxy'
+require 'floss/log/simple'
+require 'floss/log/redis'
+
+include Celluloid::Logger
+
+class FSM
+  def initialize
+    @content = Hash.new
+  end
+
+  def set(key, value)
+    @content[key] = value
+  end
+
+  def get(key)
+    @content[key]
+  end
+end
+
+CLUSTER_SIZE = 5
+
+ids = CLUSTER_SIZE.times.map do |i|
+  port = 50000 + i
+  "tcp://127.0.0.1:#{port}"
+end
+
+proxies = Floss::TestHelper.cluster(ids) do |id, peers|
+  db = id.split(':').last.to_i - 50000
+  Floss::Proxy.new(FSM.new, id: id, peers: peers, log: Floss::Log::Redis, redis_db: db)
+end
+
+100.times do |i|
+  proxies.sample.set(:foo, i)
+  raise "fail" unless proxies.sample.get(:foo) == i
+end

--- a/floss.gemspec
+++ b/floss.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'fakeredis'
   gem.add_runtime_dependency 'celluloid-zmq'
   gem.add_runtime_dependency 'celluloid-io'
 end

--- a/lib/floss/log/redis.rb
+++ b/lib/floss/log/redis.rb
@@ -1,0 +1,88 @@
+require 'forwardable'
+require 'floss'
+require 'floss/log'
+require 'celluloid/redis'
+require 'celluloid/io'
+
+# See Section 5.3.
+class Floss::Log
+  class Redis < Floss::Log
+    include Celluloid
+    extend Forwardable
+
+    DEFAULT_OPTIONS = {
+      redis_port: 6379,
+      redis_host: '127.0.0.1',
+      redis_db: 0
+    }
+
+    def initialize(options={})
+      @options = DEFAULT_OPTIONS.merge(options)
+      @k = 'raft_log'
+      @r = ::Redis.new(host: @options[:redis_host],
+                       port: @options[:redis_port],
+                       db: @options[:redis_db])
+    end
+
+    # @param [Array] The entries to append to the log.
+    def append(new_entries)
+      raise ArgumentError, 'The passed array is empty.' if new_entries.empty?
+      new_entries.each do |e|
+        @r.rpush(@k, Marshal.dump(e))
+      end
+      last_index
+    end
+
+    def empty?
+      @r.llen(@k) == 0
+    end
+
+    def [](idx)
+      v = @r.lindex(@k, idx)
+      return nil if v.nil?
+      Marshal.load(v)
+    end
+
+    def []=(idx,v)
+      @r.lset(@k,idx,Marshal.dump(v))
+    end
+
+    def starting_with(index)
+      @r.lrange(@k, index, -1).map do |e|
+        Marshal.load(e)
+      end
+    end
+
+    # Returns the last index in the log or nil if the log is empty.
+    def last_index
+      len = @r.llen(@k)
+      return nil if len == 0
+      len > 0 ? len - 1 : nil
+    end
+
+    # Returns the term of the last entry in the log or nil if the log is empty.
+    def last_term
+      return nil if empty?
+      e = @r.lindex(@k,@r.llen(@k) - 1)
+      entry = Marshal.load(e)
+      entry ? entry.term : nil
+    end
+
+    def validate(index, term)
+      # Special case: Accept the first entry if the log is empty.
+      return empty? if index.nil? && term.nil?
+      e = @r.lindex(@k, index)
+      return nil if e.nil?
+      entry = Marshal.load(e)
+      entry && entry.term == term
+    end
+
+    def remove_starting_with(index)
+      if index == 0
+        @r.del(@k)
+      else
+        @r.ltrim(@k, index, -1)
+      end
+    end
+  end
+end

--- a/lib/floss/node.rb
+++ b/lib/floss/node.rb
@@ -69,7 +69,7 @@ class Floss::Node
     raise 'Already running' if @running
 
     @running = true
-    @log = @options[:log].new
+    @log = @options[:log].new @options
 
     self.server = link(rpc_server_class.new(id, &method(:handle_rpc)))
     @election_timeout = after(random_timeout) { on_election_timeout }

--- a/spec/functional/log_spec.rb
+++ b/spec/functional/log_spec.rb
@@ -1,5 +1,6 @@
 require 'floss/log'
 require 'floss/log/simple'
+require 'floss/log/redis'
 
 shared_examples 'a Log implementation' do
 
@@ -55,5 +56,9 @@ shared_examples 'a Log implementation' do
 end
 
 describe Floss::Log::Simple do
+  it_should_behave_like 'a Log implementation'
+end
+
+describe Floss::Log::Redis do
   it_should_behave_like 'a Log implementation'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $: << File.expand_path('../../lib', __FILE__)
 
 require 'logger'
 require 'celluloid'
+require 'fakeredis/rspec'
 
 logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'w')
 logfile.sync = true


### PR DESCRIPTION
This implements an initial pass at a persistent log in Redis.

It also adds another example script which uses this new log backend and an initial set of specs to describe the Floss::Log class.
